### PR TITLE
Fix image decode warning

### DIFF
--- a/lib.typ
+++ b/lib.typ
@@ -38,7 +38,7 @@
       baseline: baseline,
       height: height,
       width: width,
-      image.decode(colorizedImage)
+      image(bytes(colorizedImage))
     )
 }
 


### PR DESCRIPTION
Fix

warning: `image.decode` is deprecated, directly pass bytes to `image` instead
   ┌─ ../lib.typ:41:12
   │
41 │       image.decode(colorizedImage)
   │             ^^^^^^